### PR TITLE
Added public spec/graph support

### DIFF
--- a/server/models/graph.py
+++ b/server/models/graph.py
@@ -56,6 +56,11 @@ class Graph(AccessControlledModel):
             'creatorId': creator['_id']
         }
 
+        if graph['public'] and creator.get('admin'):
+            self.setPublic(doc=obj, public=True)
+        else:
+            obj['public'] = False
+
         if save:
             obj = self.save(obj)
 
@@ -70,4 +75,5 @@ class Graph(AccessControlledModel):
         :returns: The graph document that was edited.
         """
         graph['updated'] = datetime.datetime.utcnow()
+        
         return self.save(graph)     

--- a/server/models/graph.py
+++ b/server/models/graph.py
@@ -14,7 +14,7 @@ class Graph(AccessControlledModel):
         self.name = 'graph'
         
         self.exposeFields(level=AccessType.READ, fields={
-            '_id', 'name', 'created', 'description', 'content', 'creatorId'})
+            '_id', 'name', 'created', 'description', 'content', 'creatorId', 'public'})
 
         
     def validate(self, graph):

--- a/server/models/spec.py
+++ b/server/models/spec.py
@@ -29,7 +29,7 @@ class Spec(AccessControlledModel):
         self.name = 'spec'
         
         self.exposeFields(level=AccessType.READ, fields={
-            '_id', 'name', 'created', 'content', 'description', 'creatorId'})
+            '_id', 'name', 'created', 'content', 'description', 'creatorId', 'public'})
 
         
     def validate(self, spec):
@@ -66,12 +66,15 @@ class Spec(AccessControlledModel):
         
         obj = {
             'name': spec['name'],
-        #    'description': spec['description'],
-        #    'icon': spec['icon'],
             'content': spec['content'],
             'created': now,
             'creatorId': creator['_id']
         }
+
+        if spec['public'] and creator.get('admin'):
+            self.setPublic(doc=obj, public=True)
+        else:
+            obj['public'] = False
 
         if save:
             obj = self.save(obj)


### PR DESCRIPTION
If the user is an admin and the spec or graph has public=true, then allow public access. Otherwise, set public to false.