### PR TITLE
Added event handler to store oauth token for user

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,8 +1,20 @@
 from rest import spec, graph
+from girder import events
+from girder.utility.model_importer import ModelImporter
+from girder.plugins.oauth.providers.github import GitHub
+
+
+def storeToken(event):
+    user, token = event.info['user'], event.info['token']
+
+    user['_oauthToken'] = token
+    ModelImporter.model('user').save(user, validate=False)
 
 
 def load(info):
     info['apiRoot'].spec = spec.Spec()
     info['apiRoot'].graph = graph.Graph()
     
-    
+    GitHub.addScopes(['user:email', 'public_repo'])
+
+    events.bind('oauth.auth_callback.after', 'cis', storeToken) 


### PR DESCRIPTION
Fixes https://github.com/cropsinsilico/Cis_Repository/issues/132

Added event handler to store Github oauth token on user model.  Requires `public_repo` scope to be able to create the pull request.