### PR TITLE
Fix Docker build - something was missing from /girder/plugin/cis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ ARG PLUGIN_NAME="cis"
 
 RUN pip install gitpython pyaml cis_interface
 
-COPY README.md server/ plugin* /girder/plugins/${PLUGIN_NAME}/
+COPY . /girder/plugins/${PLUGIN_NAME}/
 COPY Dockerfile /girder
 COPY girder.local.cfg /girder/girder/conf/


### PR DESCRIPTION
* Fixed [girder](https://hub.docker.com/r/cropsinsilico/girder/tags/) Docker image (no longer requires plugin source mapped-in)